### PR TITLE
Fix cta buttons being displayed over the popovers

### DIFF
--- a/app/components/ui/popover.tsx
+++ b/app/components/ui/popover.tsx
@@ -24,7 +24,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-72 rounded-xl bg-popoverBackground p-4 text-white shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-[9999] w-72 rounded-xl bg-popoverBackground p-4 text-white shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
       {...props}


### PR DESCRIPTION
### Now
<img width="764" alt="image" src="https://github.com/user-attachments/assets/fa66bea0-aa5d-47e7-ae37-e3f54bc279a0">

<img width="538" alt="image" src="https://github.com/user-attachments/assets/a9392688-15c7-417b-83a8-868c0817ae74">

### Before
![image](https://github.com/user-attachments/assets/f44ad988-c1f8-4e45-a0eb-328da23a7430)
