### PR TITLE
Fix Staking card navigation in features page

### DIFF
--- a/app/(main)/features/components/cards/StakeCard.tsx
+++ b/app/(main)/features/components/cards/StakeCard.tsx
@@ -22,7 +22,7 @@ export const StakeCard = ({ data }: { data: FetchedData }) => {
 
   return (
     <FeaturesPageCard
-      id="seal"
+      id="stake"
       isAlpha
       tabs={[
         {


### PR DESCRIPTION
Fix for: Clicking Staking Engine here doesn’t take you down to the staking engine section

![image](https://github.com/user-attachments/assets/05ca771f-621b-4b46-affd-34c9a74184c3)
