### PR TITLE
Pnpm minimum release age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,0 @@
-minimumReleaseAge: 1440


### PR DESCRIPTION
### What does this PR do?
- Specify the pnpm version to use in the package.json
- Sets the minimum release age for new packages to 24 hours, so that a new package version needs to be at least 24 hours old before it can be installed in the monorepo
- Remove old pnpm configs that were using the default values and update the preferred file for configs from the `.npmrc` file to the `pnpm-workspace.yaml` file