### PR TITLE
Add cross-domain PostHog attribution via URL params 

### DIFF
--- a/app/components/ExternalLink.tsx
+++ b/app/components/ExternalLink.tsx
@@ -1,3 +1,4 @@
+import posthog from 'posthog-js';
 import { cn } from '../lib/utils';
 import { useAppContext } from '../context/AppContext';
 import { ALLOWED_DOMAINS, RESTRICTED_DOMAINS } from '../constants';
@@ -55,6 +56,17 @@ export function ExternalLink({
       e.preventDefault();
       setExternalLinkModalUrl(href);
       setExternalLinkModalOpened(true);
+      return;
+    }
+
+    // For app links, append PostHog identity params at click time
+    // (PostHog may not be loaded during render, so we do this here)
+    if (isAppLink) {
+      const finalUrl = appendPostHogParams(href);
+      if (finalUrl !== href) {
+        e.preventDefault();
+        window.open(finalUrl, target);
+      }
     }
   };
 
@@ -68,4 +80,25 @@ export function ExternalLink({
       {children}
     </a>
   );
+}
+
+/**
+ * Appends PostHog identity params to a URL for cross-domain attribution.
+ * Called at click time (not render time) because PostHog may not be loaded during render.
+ */
+function appendPostHogParams(url: string): string {
+  try {
+    const distinctId = posthog.get_distinct_id?.();
+    const sessionId = posthog.get_session_id?.();
+
+    // Don't append if PostHog isn't initialized or IDs are the cookieless placeholder
+    if (!distinctId || distinctId === '$posthog_cookieless') return url;
+
+    const urlObj = new URL(url);
+    if (distinctId) urlObj.searchParams.set('__ph_id', distinctId);
+    if (sessionId) urlObj.searchParams.set('__ph_session_id', sessionId);
+    return urlObj.toString();
+  } catch {
+    return url;
+  }
 }

--- a/app/providers/PostHogProvider.tsx
+++ b/app/providers/PostHogProvider.tsx
@@ -48,14 +48,11 @@ let hasInitializedPostHog = false;
 // Consent is stored in the cross-subdomain sky_consent cookie (shared across *.sky.money).
 //
 // - Rejected users: PostHog is NOT initialized at all (zero events, zero network requests).
-// - Pending users: Cookieless anonymous tracking via server-side hash (cookieless_mode: 'always').
+// - Pending users: Memory-only persistence (persistence: 'memory'). Each user gets a real UUID
+//   distinct_id that lives only in JavaScript heap memory — no cookies, localStorage, or
+//   sessionStorage. Cleared on page close/refresh. This enables cross-domain attribution
+//   by passing the UUID via URL params when navigating to app.sky.money.
 // - Accepted users: Full persistent tracking from the first $pageview.
-//
-// Why cookieless_mode: 'always' for pending users (not 'on_reject')?
-// The 'on_reject' mode only activates when isExplicitlyOptedOut() is true, which requires
-// an explicit opt_out_capturing() call — opt_out_capturing_by_default doesn't trigger it.
-// Using 'always' guarantees cookieless tracking from the first event for pending users.
-// The CookieConsentBanner switches the mode via set_config() when the user makes a choice.
 export function initializePostHogIfNeeded(forceAccepted = false) {
   if (typeof window === 'undefined' || !POSTHOG_ENABLED || !POSTHOG_KEY || hasInitializedPostHog) {
     return;
@@ -84,20 +81,11 @@ export function initializePostHogIfNeeded(forceAccepted = false) {
     // Also includes scroll depth metrics (max_scroll, last_scroll) automatically.
     capture_pageleave: true,
 
-    // PERSISTENCE: localStorage+cookie for cross-session and cross-subdomain attribution.
-    // Most data stored in localStorage (keeps headers small), but identity properties
-    // (distinct_id, device_id, session_id) are also persisted in cookies so that
-    // cross_subdomain_cookie: true can share them across *.sky.money subdomains.
-    persistence: 'localStorage+cookie',
-
-    // COOKIELESS MODE
-    // Pending users: 'always' → server-side hashed identity, no cookies/localStorage for tracking.
-    //   distinct_id is '$posthog_cookieless' (replaced server-side with daily hash).
-    //   Each day produces a new hash, so cross-day tracking is impossible.
-    // Accepted users: undefined → full persistent tracking with stable UUID distinct_id.
-    // Rejected users: never reach here (PostHog not initialized).
-    // Requires "Cookieless server hash mode" enabled in PostHog project settings.
-    cookieless_mode: hasAccepted ? undefined : 'always',
+    // PERSISTENCE
+    // Accepted users: localStorage+cookie for cross-session and cross-subdomain attribution.
+    // Pending users: memory only — UUID exists in JS heap, no device storage.
+    //   Enables cross-domain attribution via URL params (see ExternalLink component).
+    persistence: hasAccepted ? 'localStorage+cookie' : 'memory',
 
     autocapture: true,
 
@@ -120,7 +108,7 @@ export function initializePostHogIfNeeded(forceAccepted = false) {
 
       // Restore consent for returning accepted users.
       // Rejected users never reach here (PostHog not initialized).
-      // Pending users are already in cookieless mode via cookieless_mode: 'always'.
+      // Pending users use memory persistence — no opt-in needed.
       if (hasAccepted) {
         posthogClient.opt_in_capturing();
       }
@@ -139,7 +127,7 @@ initializePostHogIfNeeded();
 
 /**
  * Apply a consent change at runtime.
- * Handles the cookieless → full tracking transition (and vice versa)
+ * Handles the memory → full tracking transition (and vice versa)
  * using the global posthog singleton directly.
  * Consent is written to the cross-subdomain sky_consent cookie via saveConsent().
  */
@@ -148,16 +136,13 @@ export function applyPostHogConsent(enabled: boolean) {
     // Ensure PostHog is initialized (handles rejected → accepted transition)
     initializePostHogIfNeeded(true);
 
-    // Disable cookieless mode and switch to full persistent tracking.
-    // reset() clears the cookieless $posthog_cookieless distinct_id
-    // so opt_in_capturing() generates a fresh persistent UUID.
-    posthog.set_config({ cookieless_mode: undefined });
-    posthog.reset();
+    // Upgrade from memory to persistent storage and opt in.
+    // The existing in-memory distinct_id carries over so the session continues seamlessly.
+    posthog.set_config({ persistence: 'localStorage+cookie' });
     posthog.opt_in_capturing();
     posthog.register({ app_name: 'marketing' });
   } else {
     if (!hasInitializedPostHog) return;
-    posthog.set_config({ cookieless_mode: undefined });
     // reset() MUST come before opt_out — reset clears all stored data including
     // opt flags. opt_out_capturing() must be last so the opt-out flag persists.
     posthog.reset();


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
  - Switch pending users (no cookie consent yet) from `cookieless_mode: 'always'` to `persistence: 'memory'`, giving each user a real UUID instead of the generic `$posthog_cookieless` placeholder
  - Append `__ph_id` and `__ph_session_id` URL params to CTA links at click time (in `ExternalLink`) for cross-domain identity passing to app.sky.money
  - Remove `cookieless_mode` entirely — memory persistence handles privacy without device storage

  ## Why
  Attribution was broken for users who hadn't accepted cookies. When a user landed on sky.money with UTM params, clicked a CTA to app.sky.money, and completed a transaction, the event couldn't be attributed to
  the original traffic source because `$posthog_cookieless` is a non-unique server-side hash that can't be passed across domains.

  ## How it works
  1. Pending users get `persistence: 'memory'` — a real UUID in JS heap, no cookies/localStorage
  2. When a user clicks a CTA, `ExternalLink` reads the PostHog `distinct_id` and `session_id` and appends them as `__ph_id` and `__ph_session_id` query params
  3. The app reads these params at init and bootstraps PostHog with the same identity
  4. Session properties (`$entry_referring_domain`, `$entry_utm_source`) carry through automatically via the shared session

  ## What doesn't change
  - Accepted users: still `persistence: 'localStorage+cookie'` with full tracking
  - Rejected users: PostHog still not initialized at all
  - Consent storage (`sky_consent` cookie) unchanged
  - No changes to event names or properties

  ## Test plan
  - [ ] Open incognito → sky.money with `?utm_source=test`
  - [ ] Do NOT accept cookie banner
  - [ ] Console: `posthog.get_distinct_id()` returns a UUID (not `$posthog_cookieless`)
  - [ ] Hover a CTA → URL includes `__ph_id` and `__ph_session_id` params
  - [ ] Click CTA → app.sky.money opens with params
  - [ ] Verify rejected users: PostHog not initialized, CTA URLs have no PostHog params