### PR TITLE
Add consent-aware person_profiles to PostHog config

### DIFF
--- a/app/providers/PostHogProvider.tsx
+++ b/app/providers/PostHogProvider.tsx
@@ -69,6 +69,12 @@ export function initializePostHogIfNeeded(forceAccepted = false) {
   posthog.init(POSTHOG_KEY, {
     api_host: POSTHOG_HOST,
 
+    // PERSON PROFILES
+    // 'always' ensures PostHog creates person profiles for all users, including
+    // pending-consent users with memory-only persistence. Without this, the SDK
+    // defaults to 'identified_only' which requires posthog.identify() calls.
+    person_profiles: 'always',
+
     // PAGE VIEW TRACKING
     // 'history_change' automatically captures $pageview on every URL change.
     // Works with App Router client-side navigation.

--- a/app/providers/PostHogProvider.tsx
+++ b/app/providers/PostHogProvider.tsx
@@ -70,10 +70,10 @@ export function initializePostHogIfNeeded(forceAccepted = false) {
     api_host: POSTHOG_HOST,
 
     // PERSON PROFILES
-    // 'always' ensures PostHog creates person profiles for all users, including
-    // pending-consent users with memory-only persistence. Without this, the SDK
-    // defaults to 'identified_only' which requires posthog.identify() calls.
-    person_profiles: 'always',
+    // Accepted users: 'always' creates person profiles with browser/OS properties.
+    // Pending users: 'identified_only' defers profile creation until consent is granted.
+    // Upgraded to 'always' at runtime in applyPostHogConsent() when user accepts.
+    person_profiles: hasAccepted ? 'always' : 'identified_only',
 
     // PAGE VIEW TRACKING
     // 'history_change' automatically captures $pageview on every URL change.
@@ -144,7 +144,7 @@ export function applyPostHogConsent(enabled: boolean) {
 
     // Upgrade from memory to persistent storage and opt in.
     // The existing in-memory distinct_id carries over so the session continues seamlessly.
-    posthog.set_config({ persistence: 'localStorage+cookie' });
+    posthog.set_config({ persistence: 'localStorage+cookie', person_profiles: 'always' });
     posthog.opt_in_capturing();
     posthog.register({ app_name: 'marketing' });
   } else {


### PR DESCRIPTION
## Summary
  - Adds `person_profiles` to `posthog.init()` — set to `'always'` for accepted users and `'identified_only'` for pending-consent users
  - On consent granted, upgrades to `'always'` via `set_config()` alongside the existing persistence upgrade
  - Without this setting, the SDK defaults to `identified_only` which requires `posthog.identify()` calls — resulting in "No defined properties" for all persons in insights
  - This was implicitly working before the memory persistence migration (c24f470) because cookieless mode triggered server-side person processing

Related ticket: APP-119

  ## Test plan
  - [ ] Run locally, open DevTools Console (PostHog debug mode logs events)
  - [ ] Before accepting cookies: verify events include `$process_person_profile: false`
  - [ ] After accepting cookies: verify events include `$process_person_profile: true`
  - [ ] Check PostHog dev project — consented persons should show browser/OS properties